### PR TITLE
Added Covering Index Support - feature supported only on PG 11

### DIFF
--- a/Library/Postgres.NET.Tests/SchemaUpdaterTests.cs
+++ b/Library/Postgres.NET.Tests/SchemaUpdaterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Npgsql;
 using Xunit;
 
@@ -16,6 +17,21 @@ namespace Postgres.NET.Tests
             using var schemaUpdater = new SchemaUpdater(new NpgsqlConnection(ConnectionString));
 
             Assert.NotEqual(0, schemaUpdater.CreateTable("testTable"));
+        }
+
+        [Fact]
+        public void CreateCovering_ShouldSucceed_ForExistingTableNameAndProperListOfColumns()
+        {
+            using var schemaUpdater = new SchemaUpdater(new NpgsqlConnection(ConnectionString));
+            
+            var tableName = "testTableCoveringIndex";
+            var columnNames = new [] { "firstColumn", "secondColumn", "thirdColumn" };
+            var columns = columnNames.Select(column => $"{column} int").ToArray();
+            var include = new [] { "thirdColumn" };
+
+            schemaUpdater.CreateTable(tableName, columns);
+
+            Assert.NotEqual(0, schemaUpdater.AddCoveringIndex(tableName, $"{tableName}_covering_idx", columnNames, include));
         }
     }
 }

--- a/Library/Postgres.NET/SchemaUpdater.cs
+++ b/Library/Postgres.NET/SchemaUpdater.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Dapper;
 using Npgsql;
 
@@ -13,11 +15,32 @@ namespace Postgres.NET
             this.databaseConnection = databaseConnection;
         }
 
-        public int CreateTable(string tableName)
+        public int CreateTable(string tableName, params string [] columns)
+        {            
+            return databaseConnection.Execute(
+                $@"CREATE TABLE {tableName} (
+                    { Zip("id serial PRIMARY KEY", columns) }
+                );");
+        }        
+
+        public int AddCoveringIndex(string tableName, string indexName, string[] columns, string [] include)
         {
             return databaseConnection.Execute(
-                $"CREATE TABLE {tableName} ( id serial PRIMARY KEY );");
+                $"CREATE INDEX {indexName} ON {tableName}({Zip(columns)}) INCLUDE ({Zip(include)});");
         }
+
+        private string Zip(string firstColumn, string [] items)
+        {
+            return Zip(new []{ firstColumn }.Union(items ?? Array.Empty<string>()));
+        }
+
+        private string Zip(IEnumerable<string> items)
+        {
+            return items?.Count() > 0 ? 
+                string.Join(',', items) 
+                : string.Empty;
+        }
+
 
         public void Dispose()
         {


### PR DESCRIPTION
Covering Index is feature that was introduced in PG 11. It doesn't exist in PG 9 and 10 (read more [here](https://paquier.xyz/postgresql-2/postgres-11-covering-indexes/) or [here](https://paquier.xyz/postgresql-2/postgres-11-covering-indexes/))

This PR fails by purpose to show that pipeline will properly catch the incompatible change for older Postgres versions (9 and 10).